### PR TITLE
fix-conversion-from-hsl-to-rgba-for-zero-saturation

### DIFF
--- a/lib/color_conversion/converters/hsl_converter.rb
+++ b/lib/color_conversion/converters/hsl_converter.rb
@@ -48,8 +48,8 @@ module ColorConversion
       {r: rgb[0], g: rgb[1], b: rgb[2], a: a}
     end
 
-    def greyscale(luminocity, alpha)
-      rgb_equal_value = (luminocity * 255).round
+    def greyscale(luminosity, alpha)
+      rgb_equal_value = (luminosity * 255).round
       { r: rgb_equal_value, g: rgb_equal_value, b: rgb_equal_value, a: alpha }
     end
 

--- a/lib/color_conversion/converters/hsl_converter.rb
+++ b/lib/color_conversion/converters/hsl_converter.rb
@@ -15,7 +15,7 @@ module ColorConversion
       l = hsl[:l].to_s.gsub(/[^0-9\.]/, "").to_f / 100.0
       a = hsl[:a] ? hsl[:a].to_s.gsub(/[^0-9\.]/, "").to_f : 1.0
 
-      return [l * 255, l * 255, l * 255] if s == 0
+      return greyscale(l, a) if s == 0
 
       t2 = if l < 0.5
         l * (1 + s)
@@ -47,5 +47,11 @@ module ColorConversion
       
       {r: rgb[0], g: rgb[1], b: rgb[2], a: a}
     end
+
+    def greyscale(luminocity, alpha)
+      rgb_equal_value = (luminocity * 255).round
+      { r: rgb_equal_value, g: rgb_equal_value, b: rgb_equal_value, a: a }
+    end
+
   end
 end

--- a/lib/color_conversion/converters/hsl_converter.rb
+++ b/lib/color_conversion/converters/hsl_converter.rb
@@ -50,7 +50,7 @@ module ColorConversion
 
     def greyscale(luminocity, alpha)
       rgb_equal_value = (luminocity * 255).round
-      { r: rgb_equal_value, g: rgb_equal_value, b: rgb_equal_value, a: a }
+      { r: rgb_equal_value, g: rgb_equal_value, b: rgb_equal_value, a: alpha }
     end
 
   end

--- a/spec/converters/hsl_converter_spec.rb
+++ b/spec/converters/hsl_converter_spec.rb
@@ -37,5 +37,11 @@ describe HslConverter do
       rgba = {r: 65, g: 105, b: 225, a: 0.5}
       expect(conv.rgba).to eq rgba
     end
+
+    it 'should return equal values when saturation is 0' do
+      conv = HslConverter.new(h: "225", s: "0%", l: "20%", a: "0.5")
+      rgba = {r: 51, g: 51, b: 51, a: 0.5}
+      expect(conv.rgba).to eq rgba
+    end
   end
 end


### PR DESCRIPTION
return a hash of equal rgb values to handle conversions from hsl that are 0 saturation

hsl to rgba conversion was returning an array, not a hash as is done in all cases besides when the saturation is 0. Created a new private method that will handle returning an even value for rgb equal to the luminosity passed in if the saturation is 0.

To reproduce bug:
```
black_hsl = ColorConversion::Color.new('#000000').hsl
ColorConversion::Color.new(black_hsl).hex
```